### PR TITLE
Standardize configuration implementation, use sane defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ Turns your plaintext secret into a ciphertext encoded with a named key through t
   * `export VAULT_ADDR='http://127.0.0.1:8200'`
   * `cd /path/to/tokend && npm start -- -c config/dev.json`
 5. start ACS
-  * create a config file in `/etc/acs/config.json` (see below)
   * `cd /path/to/acs`
   * `export PORT=3001`
-  * `npm start`
+  * `npm start -- -c config/dev.json`
   * navigate to localhost:3001 in your browser
 
 ### Configuration
 
-ACS's config file lives in `/etc/acs/config.json`, it looks something like this:
+You specify a configuration file at run time like this:
+`npm start -- -c path/to/your/config.json`
+
+Here is a full example of a config.json with all of the available configuration parameters:
 
 ```json
 {

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -1,0 +1,15 @@
+{
+  "vault": {
+    "host": "127.0.0.1",
+    "port": 8200,
+    "ssl": false
+  },
+  "tokend": {
+    "host": "localhost",
+    "port": 4500,
+    "path": "/v1/token/default"
+  },
+  "log": {
+    "level": "info"
+  }
+}

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,0 +1,5 @@
+{
+  "acs": {
+    "transit_key": "your_acs_key"
+  }
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,22 @@
 'use strict';
 
+const Path = require('path');
+
+const args = require('yargs')
+  .usage('Usage: $0 [args]')
+  .option('c', {
+    alias: 'config',
+    describe: 'Load configuration from file',
+    type: 'string'
+  })
+  .help('help')
+  .argv;
+
 // Load nconf into the global namespace
 global.Config = require('nconf').env()
-  .argv()
-  .file({ file: '/etc/acs/config.json' });
+  .argv();
+
+if (args.c) {
+  Config.file(Path.resolve(process.cwd(), args.c));
+}
+Config.defaults(require('../config/defaults.json'));

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "request-promise": "^4.1.1",
     "serve-favicon": "~2.3.0",
     "vaulted": "^3.2.0",
-    "winston": "^2.2.0"
+    "winston": "^2.2.0",
+    "yargs": "^6.3.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Standardizes configuration implementation via:

- allowing user to pass a json config file at the command line
- setting sane defaults in `config/defaults.json`
- providing a `config/dev.json` with a transit key name for use in development

Environment variables and command line arguments still take precedence. Resolves #5.