### PR TITLE
Globally blacklist plaintext logging

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -33,7 +33,9 @@ Config.defaults(require('../config/defaults.json'));
 global.Log = Logger.attach(Config.get('log:level'));
 
 // Add request logging middleware
-app.use(Logger.requests(Log, Config.get('log:level')));
+if (Config.get('log:requests')) {
+  app.use(Logger.requests(Log, Config.get('log:level')));
+}
 
 // Add middleware for paring JSON requests
 app.use(BodyParser.json());

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -10,7 +10,7 @@
     "path": "/v1/token/default"
   },
   "log": {
-    "level": "info",
+    "level": "INFO",
     "requests": true,
     "json": true
   },

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,5 +1,9 @@
 {
   "acs": {
     "transit_key": "your_acs_key"
+  },
+  "log": {
+    "json": false,
+    "requests": false
   }
 }

--- a/lib/control/v1/vault.js
+++ b/lib/control/v1/vault.js
@@ -5,7 +5,6 @@ const STATUS_CODES = require('./status-codes');
 
 module.exports = function Encrypt() {
   return (req, res, next) => {
-    req._routeBlacklists.body = ['plaintext_secret'];
     const base64Plaintext = new Buffer(req.body.plaintext_secret).toString('base64');
 
     encryptCipher(base64Plaintext).then((ciphertext) => {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -54,7 +54,8 @@ function RequestLogger(logger, level) {
     msg: '{{req.method}} {{req.url}} {{res.statusCode}} {{res.responseTime}}ms',
     level: logLevel,
     baseMeta: {sourceName: 'request'},
-    meta: true
+    meta: true,
+    bodyBlacklist: ['plaintext_secret', 'plaintext', 'ciphertext']
   });
 }
 


### PR DESCRIPTION
This PR moves blacklisting the `plaintext_secret` property in the request body from the `/v1/vault` route to the request logger instantiation. This allows us to disable request logging without throwing an exception [here](https://github.com/rapid7/acs/compare/global-blacklist-plaintext-logging?expand=1#diff-0829b8e28a0e679d7cb5f5026f78a458L8).