### PR TITLE
Logic for determining available backends

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -37,6 +37,8 @@ if (Config.get('log:requests')) {
   app.use(Logger.requests(Log, Config.get('log:level')));
 }
 
+Config.set('vault:endpoint', `http${Config.get('vault:tls') ? 's' : ''}://${Config.get('vault:host')}:${Config.get('vault:port')}/${Config.get('vault:api')}`);
+
 // Add middleware for paring JSON requests
 app.use(BodyParser.json());
 

--- a/config/dev.json
+++ b/config/dev.json
@@ -3,6 +3,7 @@
     "host": "127.0.0.1",
     "port": 8200,
     "tls": false,
+    "api": "v1",
     "transit_key": "your_acs_key"
   },
   "log": {

--- a/lib/control/v1/index.js
+++ b/lib/control/v1/index.js
@@ -3,6 +3,24 @@
 const AWS = require('aws-sdk');
 const Err = require('./error');
 const upload = require('multer')();
+const rp = require('request-promise');
+
+// Hit the Vault health check endpoint to see if we're actually working with a Vault server
+
+
+/**
+ * Checks whether there is an actual Vault server running at the Vault endpoint
+ *
+ * @returns {Promise}
+ */
+const checkVault = function() {
+  const VAULT_ENDPOINT = Config.get('vault:endpoint');
+
+  return rp({uri: `${VAULT_ENDPOINT}/sys/health`, json: true})
+    .then(() => true)
+    .catch(() => false);
+};
+
 
 module.exports = function Index(app) {
   app.get('/', function(req, res, next) {

--- a/lib/control/v1/index.js
+++ b/lib/control/v1/index.js
@@ -21,25 +21,32 @@ const checkVault = function() {
     .catch(() => false);
 };
 
+/**
+ * Gets a list of KMS keys and their aliases
+ *
+ * @returns {Promise}
+ */
+const getKmsKeys = function() {
+  const KMS = new AWS.KMS({region: Config.get('aws:region')});
+
+  if (Config.get('aws:key')) {
+    return Promise.resolve([]);
+  }
+
+  return new Promise((resolve, reject) => {
+    KMS.listAliases({}, (err, data) => {
+      if (err) {
+        reject(err);
+      }
+
+      resolve(data);
+    });
+  });
+};
 
 module.exports = function Index(app) {
   app.get('/', function(req, res, next) {
-    const KMS = new AWS.KMS({region: Config.get('aws:region')});
 
-    if (Config.get('aws:key')) {
-      return res.render('index', {title: 'ACS'});
-    }
-
-    return new Promise((resolve, reject) => {
-      KMS.listAliases({}, (err, data) => {
-        if (err) {
-          reject(err);
-        }
-
-        resolve(data);
-      });
-    }).then((keys) => {
-      res.render('index', {title: 'ACS', kms: keys.Aliases});
     }).catch((err) => {
       next(err);
     });

--- a/lib/control/v1/index.js
+++ b/lib/control/v1/index.js
@@ -45,8 +45,23 @@ const getKmsKeys = function() {
 };
 
 module.exports = function Index(app) {
-  app.get('/', function(req, res, next) {
+  let keys = [];
+  const backends = {};
 
+  app.get('/', function(req, res, next) {
+    return getKmsKeys().then((k) => {
+      keys = k.Aliases;
+      backends.kms = true;
+    }).catch((err) => {
+      // If we get a KMS error we don't want to output that error to the frontend.
+      // Instead, we want to log the error and continue. This way the KMS backend
+      // will be marked as false.
+      Log.log('ERROR', err);
+      backends.kms = false;
+    }).then(() => checkVault()).then((hasVault) => {
+      backends.vault = hasVault;
+    }).then(() => {
+      res.render('index', {title: 'ACS', kms: keys, backends});
     }).catch((err) => {
       next(err);
     });

--- a/lib/control/v1/vault.js
+++ b/lib/control/v1/vault.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const encryptCipher = require('../../vault/ciphertext');
-const STATUS_CODES = require('./status-codes');
 
 module.exports = function Encrypt() {
   return (req, res, next) => {

--- a/lib/vault/ciphertext.js
+++ b/lib/vault/ciphertext.js
@@ -3,7 +3,7 @@
 const rp = require('request-promise');
 
 const TOKEND_ENDPOINT = `http://${Config.get('tokend:host')}:${Config.get('tokend:port')}${Config.get('tokend:path')}`;
-const VAULT_ENDPOINT = `http${Config.get('vault:tls') ? 's' : ''}://${Config.get('vault:host')}:${Config.get('vault:port')}`;
+const VAULT_ENDPOINT = Config.get('vault:endpoint');
 
 const getToken = () => rp({uri: TOKEND_ENDPOINT, json: true}).then((body) => body.token);
 
@@ -11,7 +11,7 @@ module.exports = function generateCiphertext(key, secret) {
   return getToken().then((token) => {
     const options = {
       method: 'POST',
-      uri: `${VAULT_ENDPOINT}/v1/transit/encrypt/${key}`,
+      uri: `${VAULT_ENDPOINT}/transit/encrypt/${key}`,
       body: {
         plaintext: secret
       },

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "node ./bin/server.js",
     "dev": "node ./bin/server.js -c ./config/dev.json",
-    "test": "./node_modules/mocha/bin/mocha",
-    "lint": "./node_modules/eslint/bin/eslint.js bin/* lib/*.js lib/**/*.js"
+    "test": "mocha",
+    "lint": "eslint bin/* lib/*.js lib/**/*.js"
   },
   "repository": {
     "type": "git",

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', function() {
   var alert = document.getElementById('alert'),
     response = document.getElementById('response');
 
-  ['vault', 'kms'].forEach(function(el) {
+  backends.forEach(function(el) {
     var submit = document.getElementById(el + '_secret_submit'),
       form = document.getElementById(el + '_form');
     submit.addEventListener('click', function() {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -14,8 +14,12 @@
           <% include ./partials/tabs %>
 
           <div class="tab-content">
-            <% include ./partials/vault %>
-            <% include ./partials/kms %>
+            <% if (backends.vault) { %>
+              <% include ./partials/vault %>
+            <% } %>
+            <% if (backends.kms) { %>
+              <% include ./partials/kms %>
+            <% } %>
           </div>
         </div>
       </div>
@@ -28,5 +32,15 @@
         </div>
       </div>
     </div>
+    <script type="text/javascript">
+      var backends = <%- JSON.stringify(backends) %>;
+      Object.keys(backends).forEach(function(el) {
+        if(!backends[el]) {
+          delete backends[el];
+        }
+      });
+      backends = Object.keys(backends);
+    </script>
+    <script src="/javascripts/application.js"></script>
   </body>
 </html>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -3,5 +3,4 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/3.0.2/normalize.min.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css" />
   <link rel='stylesheet' href='/stylesheets/style.css' />
-  <script src="/javascripts/application.js"></script>
 </head>

--- a/views/partials/tabs.ejs
+++ b/views/partials/tabs.ejs
@@ -1,4 +1,8 @@
 <ul class="tab-nav">
-  <li><p class="button active" data-target="#kms">KMS</p></li>
-  <li><p class="button" data-target="#vault">Vault</p></li>
+  <% if (backends.kms) { %>
+    <li><p class="button active" data-target="#kms">KMS</p></li>
+  <% } %>
+  <% if (backends.vault) { %>
+    <li><p class="button <% if (!backends.kms) { %>active<% } %>" data-target="#vault">Vault</p></li>
+  <% } %>
 </ul>

--- a/views/partials/vault.ejs
+++ b/views/partials/vault.ejs
@@ -1,4 +1,4 @@
-<div class="tab-pane" id="vault">
+<div class="tab-pane <% if (!backends.kms) { %>active<% } %>" id="vault">
   <div class="form-container row">
     <div class="six columns">
       <form id="vault_form" name="vault_form" enctype="multipart/form-data">


### PR DESCRIPTION
This PR adds some logic to determine which frontend components should be displayed. It assumes that if a request to Vault's `/sys/health` endpoint fails, Vault is unavailable and if an error comes back from KMS, then KMS is unavailable.