### PR TITLE
Cookbook: Guard symlink resource

### DIFF
--- a/cookbook/metadata.rb
+++ b/cookbook/metadata.rb
@@ -16,3 +16,4 @@ long_description IO.read(::File.join(project_path, 'README.md')) rescue ''
 version package_dot_json.fetch('version', '0.0.1')
 
 depends 'nodejs'
+depends 'ark', '~> 3.0.0'

--- a/cookbook/recipes/default.rb
+++ b/cookbook/recipes/default.rb
@@ -37,11 +37,15 @@ package 'acs' do
   source resources('remote_file[acs]').path
   provider Chef::Provider::Package::Dpkg
   version node['acs']['version']
+
+  notifies :create, "link[#{node['acs']['paths']['directory']}]", :immediately
 end
 
 ## Symlink the version dir to the specified acs directory
 link node['acs']['paths']['directory'] do
   to version_dir
+
+  action :nothing
   notifies :restart, 'service[acs]' if node['acs']['enable']
 end
 


### PR DESCRIPTION
This PR adds a notification guard to the symlink resource so nothing gets linked unless the service is installed.