### PR TITLE
Envelope encryption kms

### DIFF
--- a/lib/control/v1/index.js
+++ b/lib/control/v1/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AWS = require('aws-sdk');
+const KMS = require('../../kms');
 const Err = require('./error');
 const upload = require('multer')();
 const rp = require('request-promise');
@@ -21,45 +21,13 @@ const checkVault = function() {
     .catch(() => false);
 };
 
-/**
- * Validates the KMS keys provided in the Config.
- *
- * @returns {Promise}
- */
-const checkKMS = function() {
-  const regions = Config.get('aws:region');
-  const validatedRegions = Object.keys(regions).map((region) => {
-    const key = regions[region];
-    const KMS = new AWS.KMS({region});
-
-    return new Promise((resolve, reject) => {
-      KMS.describeKey({KeyId: key}, (err, data) => {
-        if (err) {
-          resolve(false);
-        }
-
-        resolve({region, key});
-      });
-    });
-  });
-
-  return Promise.all(validatedRegions).then((regions) => {
-    const filtered = regions.filter((r) => !!r);
-
-    if (filtered.length === 0) {
-      throw new Error('No valid KMS keys');
-    }
-
-    return filtered;
-  });
-};
 
 module.exports = function Index(app) {
   let regions = [];
   const backends = {};
 
   app.get('/', function(req, res, next) {
-    return checkKMS().then((r) => {
+    return KMS.check().then((r) => {
       regions = r;
       backends.kms = true;
     }).catch((err) => {

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -17,21 +17,21 @@ module.exports = () => (req, res, next) => {
 
   const region = keyObj.region;
   const key = keyObj.key;
-
   const params = {
     KeyId: key,
-    Plaintext: plaintext
+    Plaintext: plaintext,
+    region
   };
 
-  return KMS.encrypt(params, region).then((data) => {
+  return KMS.encrypt(params).then((data) => {
     res.send(
       '$tokend:\n' +
       '  type: kms\n' +
       '  resource: /v1/kms/decrypt\n' +
       '  Region: ' + data.region + '\n' +
-      '  Ciphertext: "' + data.ciphertext.toString('base64') + '"\n' +
+      '  Ciphertext: "' + data.ciphertext + '"\n' +
       '  DataKey: "' + data.datakey + '"\n' +
-      '  RoundtripStatus: ' + data.status + '\n');
+      '  RoundtripStatus: ' + data.roundTripStatus + '\n');
   }).catch((err) => {
     next(err);
   });

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -30,8 +30,7 @@ module.exports = () => (req, res, next) => {
       '  resource: /v1/kms/decrypt\n' +
       '  Region: ' + data.region + '\n' +
       '  Ciphertext: "' + data.ciphertext + '"\n' +
-      '  DataKey: "' + data.datakey + '"\n' +
-      '  RoundtripStatus: ' + data.roundTripStatus + '\n');
+      '  DataKey: "' + data.datakey + '"\n');
   }).catch((err) => {
     next(err);
   });

--- a/lib/control/v1/kms.js
+++ b/lib/control/v1/kms.js
@@ -1,48 +1,37 @@
 'use strict';
 
-const AWS = require('aws-sdk');
+const KMS = require('../../kms');
 
-module.exports = function KMS() {
-  return (req, res, next) => new Promise((resolve, reject) => {
-    const plaintext = req.body.kms_secret;
+module.exports = () => (req, res, next) => {
+  const plaintext = req.body.kms_secret;
 
-    const keyObj = JSON.parse(req.body.kms_key);
+  const keyObj = JSON.parse(req.body.kms_key);
 
-    if (!keyObj) {
-      reject(new Error('CMK not defined'));
-    }
+  if (!keyObj) {
+    return next(new Error('CMK not defined'));
+  }
 
-    if (!plaintext) {
-      reject(new Error('Plaintext not defined'));
-    }
+  if (!plaintext) {
+    return next(new Error('Plaintext not defined'));
+  }
 
-    const region = keyObj.region;
-    const key = keyObj.key;
+  const region = keyObj.region;
+  const key = keyObj.key;
 
-    const params = {
-      KeyId: key,
-      Plaintext: plaintext
-    };
+  const params = {
+    KeyId: key,
+    Plaintext: plaintext
+  };
 
-    const kms = new AWS.KMS({region});
-
-    kms.encrypt(params, (err, data) => {
-      if (err) {
-        return reject(err);
-      }
-
-      resolve({
-        ciphertext: data.CiphertextBlob,
-        key: data.KeyId,
-        region
-      });
-    });
-  }).then((data) => {
-    res.send('$tokend:\n' +
+  return KMS.encrypt(params, region).then((data) => {
+    res.send(
+      '$tokend:\n' +
       '  type: kms\n' +
       '  resource: /v1/kms/decrypt\n' +
-      '  region: ' + data.region + '\n' +
-      '  ciphertext: "' + data.ciphertext.toString('base64') + '"\n');
+      '  Region: ' + data.region + '\n' +
+      '  Ciphertext: "' + data.ciphertext.toString('base64') + '"\n' +
+      '  DataKey: "' + data.datakey + '"\n' +
+      '  RoundtripStatus: ' + data.status + '\n');
   }).catch((err) => {
     next(err);
   });

--- a/lib/kms/index.js
+++ b/lib/kms/index.js
@@ -36,26 +36,26 @@ const check = () => {
   });
 };
 
-const _round_trip_decrypt = (params) => new Promise((resolve, reject) => {
+const round_trip_decrypt = (params) => new Promise((resolve, reject) => {
   let region = params.region;
   const kms = new AWS.KMS({region});
 
 
   kms.decrypt({
     CiphertextBlob: params.encryptedDataKey
-  }, (err, data) => {
+  }, (err, kmsDecryptResponse) => {
     if (err) {
       return reject(err);
     }
-    if (data) {
-      if (data.Plaintext.toString('base64') !== params.plaintextDataKey.toString('base64')) {
+    if (kmsDecryptResponse) {
+      if (kmsDecryptResponse.Plaintext.toString('base64') !== params.plainTextDataKey.toString('base64')) {
         resolve(false);
       }
-      const decipher = crypto.createDecipher('aes-256-cbc', data.Plaintext);
-      let decryptedPlaintext = decipher.update(params.ciphertextSecret, 'base64', 'utf8');
+      const decipher = crypto.createDecipher('aes-256-cbc', kmsDecryptResponse.Plaintext);
+      let decryptedPlaintext = decipher.update(params.cipherTextSecret, 'base64', 'utf8');
 
       decryptedPlaintext += decipher.final('utf8');
-      if (decryptedPlaintext !== params.plaintextSecret) {
+      if (decryptedPlaintext !== params.plainTextSecret) {
         resolve(false);
       }
       resolve(true);
@@ -67,10 +67,10 @@ const _round_trip_decrypt = (params) => new Promise((resolve, reject) => {
  * Encrypt the data
  *
  * @param params
- * @param region
  * @return {Promise}
  */
-const encrypt = (params, region) => {
+const encrypt = (params) => {
+  const region = params.region;
   const kms = new AWS.KMS({region});
 
   return new Promise((resolve, reject) => {
@@ -86,20 +86,20 @@ const encrypt = (params, region) => {
         let ciphertext = aesCipher.update(params.Plaintext, 'utf8', 'base64');
 
         ciphertext += aesCipher.final('base64');
-        const roundtripParams = {
+        const roundTripParams = {
           encryptedDataKey: kmsResponse.CiphertextBlob,
-          ciphertextSecret: ciphertext,
+          cipherTextSecret: ciphertext,
           region,
-          plaintextDataKey: kmsResponse.Plaintext,
-          plaintextSecret: params.Plaintext
+          plainTextDataKey: kmsResponse.Plaintext,
+          plainTextSecret: params.Plaintext
         };
 
-        _round_trip_decrypt(roundtripParams).then((data) => {
+        round_trip_decrypt(roundTripParams).then((roundTripStatus) => {
           resolve({
             region,
             datakey: kmsResponse.CiphertextBlob.toString('base64'),
-            ciphertext,
-            status: data
+            ciphertext: ciphertext.toString('base64'),
+            roundTripStatus
           });
         });
       }
@@ -111,5 +111,3 @@ module.exports = {
   encrypt,
   check
 };
-
-

--- a/lib/kms/index.js
+++ b/lib/kms/index.js
@@ -1,0 +1,115 @@
+'use strict';
+
+const AWS = require('aws-sdk');
+const crypto = require('crypto');
+
+/**
+ * Validates the KMS keys provided in the Config.
+ *
+ * @returns {Promise}
+ */
+const check = () => {
+  const regions = Config.get('aws:region');
+  const validatedRegions = Object.keys(regions).map((region) => {
+    const key = regions[region];
+    const KMS = new AWS.KMS({region});
+
+    return new Promise((resolve, reject) => {
+      KMS.describeKey({KeyId: key}, (err, data) => {
+        if (err) {
+          resolve(false);
+        }
+
+        resolve({region, key});
+      });
+    });
+  });
+
+  return Promise.all(validatedRegions).then((regions) => {
+    const filtered = regions.filter((r) => !!r);
+
+    if (filtered.length === 0) {
+      throw new Error('No valid KMS keys');
+    }
+
+    return filtered;
+  });
+};
+
+const _round_trip_decrypt = (params) => new Promise((resolve, reject) => {
+  let region = params.region;
+  const kms = new AWS.KMS({region});
+
+
+  kms.decrypt({
+    CiphertextBlob: params.encryptedDataKey
+  }, (err, data) => {
+    if (err) {
+      return reject(err);
+    }
+    if (data) {
+      if (data.Plaintext.toString('base64') !== params.plaintextDataKey.toString('base64')) {
+        resolve(false);
+      }
+      const decipher = crypto.createDecipher('aes-256-cbc', data.Plaintext);
+      let decryptedPlaintext = decipher.update(params.ciphertextSecret, 'base64', 'utf8');
+
+      decryptedPlaintext += decipher.final('utf8');
+      if (decryptedPlaintext !== params.plaintextSecret) {
+        resolve(false);
+      }
+      resolve(true);
+    }
+  });
+});
+
+/**
+ * Encrypt the data
+ *
+ * @param params
+ * @param region
+ * @return {Promise}
+ */
+const encrypt = (params, region) => {
+  const kms = new AWS.KMS({region});
+
+  return new Promise((resolve, reject) => {
+    kms.generateDataKey({
+      KeyId: params.KeyId,
+      KeySpec: 'AES_256'
+    }, (kmsError, kmsResponse) => {
+      if (kmsError) {
+        return reject(kmsError);
+      }
+      if (kmsResponse) {
+        const aesCipher = crypto.createCipher('aes-256-cbc', kmsResponse.Plaintext);
+        let ciphertext = aesCipher.update(params.Plaintext, 'utf8', 'base64');
+
+        ciphertext += aesCipher.final('base64');
+        const roundtripParams = {
+          encryptedDataKey: kmsResponse.CiphertextBlob,
+          ciphertextSecret: ciphertext,
+          region,
+          plaintextDataKey: kmsResponse.Plaintext,
+          plaintextSecret: params.Plaintext
+        };
+
+        _round_trip_decrypt(roundtripParams).then((data) => {
+          resolve({
+            region,
+            datakey: kmsResponse.CiphertextBlob.toString('base64'),
+            ciphertext,
+            status: data
+          });
+        });
+      }
+    });
+  });
+};
+
+module.exports = {
+  encrypt,
+  check
+};
+
+

--- a/lib/kms/index.js
+++ b/lib/kms/index.js
@@ -36,6 +36,12 @@ const check = () => {
   });
 };
 
+/**
+ * Validates that retrieving the plaintext datakey and performing a decrypt on your cipher secret
+ * returns the expected original secret
+ * @param params
+ * @returns {Promise}
+ */
 const round_trip_decrypt = (params) => new Promise((resolve, reject) => {
   let region = params.region;
   const kms = new AWS.KMS({region});
@@ -64,7 +70,7 @@ const round_trip_decrypt = (params) => new Promise((resolve, reject) => {
 });
 
 /**
- * Encrypt the data
+ * Encrypt the data by creating a new datakey and generate the ciphertext secret locally
  *
  * @param params
  * @return {Promise}

--- a/lib/kms/index.js
+++ b/lib/kms/index.js
@@ -37,39 +37,6 @@ const check = () => {
 };
 
 /**
- * Validates that retrieving the plaintext datakey and performing a decrypt on your cipher secret
- * returns the expected original secret
- * @param params
- * @returns {Promise}
- */
-const round_trip_decrypt = (params) => new Promise((resolve, reject) => {
-  let region = params.region;
-  const kms = new AWS.KMS({region});
-
-
-  kms.decrypt({
-    CiphertextBlob: params.encryptedDataKey
-  }, (err, kmsDecryptResponse) => {
-    if (err) {
-      return reject(err);
-    }
-    if (kmsDecryptResponse) {
-      if (kmsDecryptResponse.Plaintext.toString('base64') !== params.plainTextDataKey.toString('base64')) {
-        resolve(false);
-      }
-      const decipher = crypto.createDecipher('aes-256-cbc', kmsDecryptResponse.Plaintext);
-      let decryptedPlaintext = decipher.update(params.cipherTextSecret, 'base64', 'utf8');
-
-      decryptedPlaintext += decipher.final('utf8');
-      if (decryptedPlaintext !== params.plainTextSecret) {
-        resolve(false);
-      }
-      resolve(true);
-    }
-  });
-});
-
-/**
  * Encrypt the data by creating a new datakey and generate the ciphertext secret locally
  *
  * @param params
@@ -92,21 +59,10 @@ const encrypt = (params) => {
         let ciphertext = aesCipher.update(params.Plaintext, 'utf8', 'base64');
 
         ciphertext += aesCipher.final('base64');
-        const roundTripParams = {
-          encryptedDataKey: kmsResponse.CiphertextBlob,
-          cipherTextSecret: ciphertext,
+        resolve({
           region,
-          plainTextDataKey: kmsResponse.Plaintext,
-          plainTextSecret: params.Plaintext
-        };
-
-        round_trip_decrypt(roundTripParams).then((roundTripStatus) => {
-          resolve({
-            region,
-            datakey: kmsResponse.CiphertextBlob.toString('base64'),
-            ciphertext: ciphertext.toString('base64'),
-            roundTripStatus
-          });
+          datakey: kmsResponse.CiphertextBlob.toString('base64'),
+          ciphertext: ciphertext.toString('base64')
         });
       }
     });


### PR DESCRIPTION
This is a pull request for the envelope encryption feature. Previously secrets were being encrypted only using a KMS CMK.

This new feature instead queries KMS for a new data encrpytion key (DEK) and then locally encrypts the secret using the fresh datakey. 

The service will now respond with the encrypted DEK and ciphertext secret rather than just a single ciphertext secret generated from a CMK. 

Additionally the response will contain a boolean RoundTripStatus stating whether or not a secondary  decryption operation successfully returned the original plaintext secret.