### PR TITLE
Add key name field

### DIFF
--- a/client/src/components/KMSTabPanel.js
+++ b/client/src/components/KMSTabPanel.js
@@ -63,9 +63,11 @@ class KMSTabPanel extends Component {
         selectedValues.push(value);
       }
 
+      const display = (r.name) ? `${r.name} (${r.account} - ${r.region})` : `${r.account} - ${r.region}`;
+
       keys.push(
         <option key={r.key} value={value}>
-          {`${r.account} - ${r.region}`}
+          {display}
         </option>
       );
     });

--- a/client/src/components/KMSTabPanel.js
+++ b/client/src/components/KMSTabPanel.js
@@ -77,7 +77,7 @@ class KMSTabPanel extends Component {
         <div className="row">
           <div className="six columns">
             <form id="kms_form" name="kms_form" onSubmit={this.handleSubmit}>
-              <p>Select the region in which to encrypt your secret:</p>
+              <p>Select the key with which to encrypt your secret:</p>
               <select
                 multiple
                 className="u-full-width"

--- a/src/config/dev.json
+++ b/src/config/dev.json
@@ -14,7 +14,8 @@
     {
       "account": "",
       "region": "",
-      "key": ""
+      "key": "",
+      "name": ""
     },
     {
       "account": "",

--- a/src/lib/kms/index.js
+++ b/src/lib/kms/index.js
@@ -8,7 +8,7 @@ import crypto from 'crypto';
  */
 export const check = async () => {
   const keys = Config.get('aws');
-  const validatedKeys = keys.map(async ({region, key}) => {
+  const validatedKeys = keys.map(async ({region, key, name}) => {
     const KMS = new AWS.KMS({region});
     let resp;
 
@@ -21,7 +21,8 @@ export const check = async () => {
     return {
       account: resp.AWSAccountId,
       key: resp.KeyId,
-      region
+      region,
+      ...(name ? {name} : {})
     };
   });
 


### PR DESCRIPTION
This PR adds an additional field in the AWS key configuration object which allows operators to specify a friendly name for a given key.