### PR TITLE
Auto select first KMS key if there is only 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ gem 'fpm', '~> 1.6'
 gem 'octokit', '~> 4.0'
 gem 'mime-types', '~> 3.1'
 
+# Vulns noted by GitHub
+gem "ffi", ">= 1.9.24"
+gem "rack", ">= 1.6.11"
+
 group :cookbook do
   gem 'builderator', '~> 1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.1)
       faraday (>= 0.7.4, < 1.0)
-    ffi (1.9.18)
+    ffi (1.10.0)
     ffi-yajl (2.3.0)
       libyajl2 (~> 1.2)
     fpm (1.8.1)
@@ -184,7 +184,7 @@ GEM
     plist (3.1.0)
     proxifier (1.0.3)
     public_suffix (2.0.5)
-    rack (1.6.5)
+    rack (1.6.11)
     rake (10.5.0)
     retryable (2.0.4)
     ridley (4.6.1)
@@ -263,10 +263,12 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk (~> 2.2)
   builderator (~> 1.0)
+  ffi (>= 1.9.24)
   fpm (~> 1.6)
   mime-types (~> 3.1)
   octokit (~> 4.0)
+  rack (>= 1.6.11)
   rake (~> 10.5)
 
 BUNDLED WITH
-   1.13.6
+   2.0.1

--- a/client/src/components/KMSTabPanel.js
+++ b/client/src/components/KMSTabPanel.js
@@ -18,6 +18,12 @@ class KMSTabPanel extends Component {
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
+  componentDidMount() {
+    if (this.state.keys.length === 1) {
+      this.setState({'selectedKeys': JSON.stringify(this.state.keys[0])})
+    }
+  }
+
   handleInputChange(event) {
     const target = event.target;
     const name = target.name;


### PR DESCRIPTION
@dgreene-r7 

Since we normally only have 1 KMS key, it is super convenient to have it be autoselected to reduce a mouse click. If there is more than 1 KMS key, the behavior will stay the same in that you still have to choose a KMS key.